### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/41Leahcim/calculator_rust_cli/releases/tag/v0.1.0) - 2024-02-20
+
+### Other
+- Added mergify
+- Added dependabot
+- Added cargo dist
+- Added the release-plz workflow
+- Added git cliff and cargo release-plz
+- Added a charactar iterator to decrease the number of allocations
+- Added a .gitignore for the target directory
+- Switched from arrays of chars to char indices iterators
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `calulator`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/41Leahcim/calculator_rust_cli/releases/tag/v0.1.0) - 2024-02-20

### Other
- Added mergify
- Added dependabot
- Added cargo dist
- Added the release-plz workflow
- Added git cliff and cargo release-plz
- Added a charactar iterator to decrease the number of allocations
- Added a .gitignore for the target directory
- Switched from arrays of chars to char indices iterators
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).